### PR TITLE
Fixed the example project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 storage.db
 todo.exe
+
+# IntelliJ files
+.idea/*

--- a/todo.go
+++ b/todo.go
@@ -5,7 +5,6 @@ import (
 
 	"./handlers"
 	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -15,11 +14,11 @@ func main() {
 
 	e := echo.New()
 	e.Static("/", "public")
-	e.Get("/tasks", handlers.GetTasks(db))
+	e.GET("/tasks", handlers.GetTasks(db))
 	e.POST("/task", handlers.PostTask(db))
-	e.Put("/task", handlers.PutTask(db))
-	e.Delete("/task/:id", handlers.DeleteTask(db))
-	e.Run(standard.New(":8080"))
+	e.PUT("/task", handlers.PutTask(db))
+	e.DELETE("/task/:id", handlers.DeleteTask(db))
+	e.Start(":8080")
 }
 
 func initDb(filepath string) *sql.DB {


### PR DESCRIPTION
It seems that the 'echo' Golang package has been refactored a bit afterwards, since some code was unusable when I tried to examine it in the editor, and `go run todo.go` threw errors mentioned in the posted issue if I tried to execute it. 